### PR TITLE
build(deps): bump buildx version to v0.23.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,6 @@ jobs:
           target: image
           build-args:
             GO_VERSION=${{ env.GO_VERSION }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   # Common versions
   GO_VERSION: '1.23.6'
   GOLANGCI_VERSION: 'v1.62.0'
-  DOCKER_BUILDX_VERSION: 'v0.11.2'
+  DOCKER_BUILDX_VERSION: 'v0.23.0'
 
   IMAGE_NAME: ghcr.io/${{ github.repository }}
   IMAGE_VERSION: ${{ inputs.version }}


### PR DESCRIPTION
### Description of your changes

Github cache API v1 has been sunset and the usage of that cache API by docker/build-push-action is causing all builds to fail. Support for newer (and still supported) versions of the cache API is possible in newer versions of buildx, so we are bumping to latest here. More details can be found in https://docs.docker.com/build/ci/github-actions/cache/#github-cache.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
