### PR TITLE
build: pass all platforms at once to docker/build-push-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,6 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: true
-      matrix:
-        arch:
-          - amd64
-          - arm64
     steps:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
@@ -98,7 +94,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/${{ matrix.arch }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: image


### PR DESCRIPTION
### Description of your changes

It looks like we are not doing multi platform builds correctly right now. For example, see the manifest at https://explore.ggcr.dev/?image=xpkg.crossplane.io%2Fcrossplane%2Fchangelogs-sidecar%3Av0.0.0-20250417151805-235afa6d306d, which does not have entries for both amd64 and arm64.

The current approach is to have a matrix of architectures that each run build/push, but I think after looking at documentation like https://docs.docker.com/build/ci/github-actions/multi-platform/, we should just be passing those multiple platforms directly to the `docker/build-push-action` and let it work on them all at once.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
